### PR TITLE
feat: prevent concurrent conversions

### DIFF
--- a/background.js
+++ b/background.js
@@ -115,6 +115,19 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
   if (msg.type === "CONVERT_M4A") {
     (async () => {
+      const current = await getJob();
+      if (current.status !== "idle") {
+        const message = "이미 다른 변환 작업이 진행 중입니다.";
+        sendResponse({ ok: false, message });
+        chrome.notifications?.create({
+          type: "basic",
+          iconUrl: "icon128.png",
+          title: "TSE",
+          message,
+        });
+        return;
+      }
+
       const job = {
         id: crypto.randomUUID(),
         url: msg.url,
@@ -132,7 +145,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         url: msg.url,
         jobId: job.id,
       });
-      sendResponse(true);
+      sendResponse({ ok: true });
     })();
     return true;
   }

--- a/popup.js
+++ b/popup.js
@@ -68,8 +68,12 @@ btnConvert.addEventListener("click", async () => {
     );
     return;
   }
+  const res = await chrome.runtime.sendMessage({ type: "CONVERT_M4A", url });
+  if (!res || res.ok === false) {
+    appendLog(res?.message || "다른 변환 작업이 이미 진행 중입니다.");
+    return;
+  }
   appendLog("변환 시작… (팝업 닫아도 계속 진행)");
-  await chrome.runtime.sendMessage({ type: "CONVERT_M4A", url });
 });
 
 btnCancel.addEventListener("click", async () => {


### PR DESCRIPTION
## Summary
- block new M4A conversions when another job is running
- show rejection message in popup when conversion is busy

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5014c647c8328b99ee68931ac1b48